### PR TITLE
Move all lightmap rendering to independent offscreen canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Example:
 
 **[Try it in this editable sandbox](https://codesandbox.io/s/github/pmndrs/react-three-lightmap/tree/v0.0.8/demo-sandbox)**.
 
-NOTE: if you are using `mode="legacy"` on your `<Canvas>` tag please add `legacySuspense` flag to the lightmap, otherwise it will not wait until your scene content is fully loaded. This is not an issue in most situations, unless you have explicitly set the mode prop on `<Canvas>`.
+NOTE: actual lightmap rendering is performed on a separate hidden canvas and WebGL context. If you are consuming any context in your lightmapped content, you will need to "bridge" that context.
 
 To track when baking is complete, provide `onComplete` callback to `Lightmap` - it will be called with the resulting texture as the first argument. The library does automatically assign that texture as the lightmap on all the baked mesh materials too.
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "typescript": "^4.1.5"
   },
   "peerDependencies": {
-    "@react-three/fiber": ">=6.0.0",
+    "@react-three/fiber": ">=8.0.0",
     "react": ">=16",
     "three": ">=0.128.0"
   },

--- a/src/core/AutoUV2.tsx
+++ b/src/core/AutoUV2.tsx
@@ -149,11 +149,18 @@ export interface AutoUV2Settings {
 }
 
 export function computeAutoUV2Layout(
-  initialWidth: number | undefined,
-  initialHeight: number | undefined,
+  lightMapSize: number | [number, number] | undefined,
   items: Generator<THREE.Object3D, void, unknown>,
   { texelsPerUnit }: AutoUV2Settings
 ): [number, number] {
+  // parse the convenience setting
+  const [initialWidth, initialHeight] = lightMapSize
+    ? [
+        typeof lightMapSize === 'number' ? lightMapSize : lightMapSize[0],
+        typeof lightMapSize === 'number' ? lightMapSize : lightMapSize[1]
+      ]
+    : [undefined, undefined];
+
   const layoutBoxes: AutoUVBox[] = [];
   let hasPredefinedUV2 = false;
 

--- a/src/core/Lightmap.tsx
+++ b/src/core/Lightmap.tsx
@@ -183,16 +183,13 @@ async function runOffscreenWorkflow(
   );
 
   const workbench = await initializeWorkbench(scene, settings, requestWork);
-
   debugListeners.onAtlasMap(workbench.atlasMap); // expose atlas map for debugging
 
   await setLightSceneMaterials(workbench);
-  await runBakingPasses(workbench, requestWork, (data) => {
-    debugListeners.onPassComplete(
-      data,
-      workbench.atlasMap.width,
-      workbench.atlasMap.height
-    );
+
+  await runBakingPasses(workbench, requestWork, (data, width, height) => {
+    // expose current pass output for debugging
+    debugListeners.onPassComplete(data, width, height);
   });
 
   return workbench;

--- a/src/core/Lightmap.tsx
+++ b/src/core/Lightmap.tsx
@@ -328,9 +328,11 @@ const Lightmap: React.FC<React.PropsWithChildren<LightmapProps>> = ({
 
   return (
     <DebugContext.Provider value={debugInfo}>
-      <scene name="Lightmap Result Scene" ref={sceneRef}>
-        {props.children}
-      </scene>
+      {result ? (
+        <scene name="Lightmap Result Scene" ref={sceneRef}>
+          {props.children}
+        </scene>
+      ) : null}
     </DebugContext.Provider>
   );
 };

--- a/src/core/Lightmap.tsx
+++ b/src/core/Lightmap.tsx
@@ -113,7 +113,6 @@ async function runWorkflow(
   return workbench;
 }
 
-// @todo merge with WorkRoot
 const LightmapMain: React.FC<
   WorkbenchSettings & {
     workPerFrame?: number; // @todo allow fractions, dynamic value
@@ -222,7 +221,7 @@ async function runOffscreenWorkflow(
     canvas.height = 64;
 
     const root = createRoot(canvas).configure({
-      // frameloop: 'demand', @todo manually control the render loop
+      frameloop: 'never', // framebuffer target rendering is inside own RAF loop
       shadows: true // @todo use the original GL context settings
     });
 

--- a/src/core/Lightmap.tsx
+++ b/src/core/Lightmap.tsx
@@ -107,7 +107,7 @@ const WorkSceneWrapper: React.FC<{
   const onReadyRef = useRef(props.onReady);
   onReadyRef.current = props.onReady;
 
-  const sceneRef = useRef<THREE.Scene>();
+  const sceneRef = useRef<THREE.Scene>(null);
   useLayoutEffect(() => {
     // kick off the asynchronous workflow process in the parent
     // (this runs when scene content is loaded and suspensions are finished)
@@ -157,13 +157,15 @@ async function runOffscreenWorkflow(
     });
 
     root.render(
-      <WorkSceneWrapper
-        onReady={(gl, scene) => {
-          resolve({ gl, scene });
-        }}
-      >
-        {content}
-      </WorkSceneWrapper>
+      <React.Suspense fallback={null}>
+        <WorkSceneWrapper
+          onReady={(gl, scene) => {
+            resolve({ gl, scene });
+          }}
+        >
+          {content}
+        </WorkSceneWrapper>
+      </React.Suspense>
     );
   });
 

--- a/src/core/Lightmap.tsx
+++ b/src/core/Lightmap.tsx
@@ -103,7 +103,7 @@ const WorkSceneWrapper: React.FC<{
 }> = (props) => {
   const { gl } = useThree(); // @todo use state selector
 
-  // track latest reference to onComplete callback
+  // track latest reference to onReady callback
   const onReadyRef = useRef(props.onReady);
   onReadyRef.current = props.onReady;
 
@@ -211,6 +211,10 @@ const Lightmap: React.FC<React.PropsWithChildren<LightmapProps>> = ({
 }) => {
   const initialPropsRef = useRef(props);
 
+  // track latest reference to onComplete callback
+  const onCompleteRef = useRef(onComplete);
+  onCompleteRef.current = onComplete;
+
   // track one-time flip from disabled to non-disabled
   // (i.e. once allowStart is true, keep it true)
   const disabledStartRef = useRef(true);
@@ -308,7 +312,7 @@ const Lightmap: React.FC<React.PropsWithChildren<LightmapProps>> = ({
       }
     );
 
-    // copy texture data since this is a foreign canvas
+    // copy texture data since this is coming from a foreign canvas
     const texture = result.createOutputTexture();
 
     updateFinalSceneMaterials(
@@ -316,6 +320,11 @@ const Lightmap: React.FC<React.PropsWithChildren<LightmapProps>> = ({
       texture,
       !!initialPropsRef.current.ao
     );
+
+    // notify listener and pass the texture instance intended for parent GL context
+    if (onCompleteRef.current) {
+      onCompleteRef.current(texture);
+    }
   }, [result]);
 
   return (

--- a/src/core/Lightmap.tsx
+++ b/src/core/Lightmap.tsx
@@ -221,28 +221,6 @@ type OffscreenSettings = WorkbenchSettings & {
   workPerFrame?: number; // @todo allow fractions, dynamic value
 };
 
-function createLightmapTexture(
-  data: Float32Array,
-  width: number,
-  height: number,
-  textureFilter: THREE.TextureFilter
-): THREE.Texture {
-  const texture = new THREE.DataTexture(
-    data,
-    width,
-    height,
-    THREE.RGBAFormat,
-    THREE.FloatType
-  );
-
-  // set same texture filter (no mipmaps supported due to the nature of lightmaps)
-  texture.magFilter = textureFilter;
-  texture.minFilter = textureFilter;
-  texture.generateMipmaps = false;
-
-  return texture;
-}
-
 async function runOffscreenWorkflow(
   scene: React.ReactNode,
   settings: OffscreenSettings
@@ -315,12 +293,7 @@ const Lightmap: React.FC<React.PropsWithChildren<LightmapProps>> = ({
     );
 
     // copy texture data since this is a foreign canvas
-    const texture = createLightmapTexture(
-      result.irradianceData,
-      result.irradianceWidth,
-      result.irradianceHeight,
-      result.irradiance.magFilter
-    );
+    const texture = result.createOutputTexture();
 
     updateFinalSceneMaterials(
       sceneRef.current,

--- a/src/core/Lightmap.tsx
+++ b/src/core/Lightmap.tsx
@@ -56,6 +56,7 @@ export const DebugContext = React.createContext<{
   outputTexture: THREE.Texture;
 } | null>(null);
 
+// main asynchronous workflow sequence
 async function runWorkflow(
   scene: THREE.Scene,
   props: WorkbenchSettings,
@@ -80,7 +81,7 @@ const LightmapMain: React.FC<
   }
 > = (props) => {
   // read once
-  const propsRef = useRef(props);
+  const initialPropsRef = useRef(props);
 
   const requestWork = useWorkRequest();
 
@@ -122,7 +123,7 @@ const LightmapMain: React.FC<
         // @todo check if this runs multiple times on some React versions???
         return runWorkflow(
           scene,
-          propsRef.current,
+          initialPropsRef.current,
           requestWork,
           (debugWorkbench) => {
             setWorkbench(debugWorkbench);
@@ -166,19 +167,18 @@ export type LightmapProps = WorkbenchSettings & {
   onComplete?: (result: THREE.Texture) => void;
 };
 
-const Lightmap = React.forwardRef<
-  THREE.Scene,
-  React.PropsWithChildren<LightmapProps>
->(({ workPerFrame, children, ...props }, sceneRef) => {
+const Lightmap: React.FC<React.PropsWithChildren<LightmapProps>> = ({
+  workPerFrame,
+  children,
+  ...props
+}) => {
   return (
     <WorkManager workPerFrame={workPerFrame}>
       <LightmapMain {...props}>
-        <scene name="Lightmap Scene" ref={sceneRef}>
-          {children}
-        </scene>
+        <scene name="Lightmap Scene">{children}</scene>
       </LightmapMain>
     </WorkManager>
   );
-});
+};
 
 export default Lightmap;

--- a/src/core/Lightmap.tsx
+++ b/src/core/Lightmap.tsx
@@ -7,7 +7,7 @@ import React, { useState, useMemo, useLayoutEffect, useRef } from 'react';
 import { useThree, createRoot } from '@react-three/fiber';
 import * as THREE from 'three';
 
-import { withLightScene, materialIsSupported } from './lightScene';
+import { setLightSceneMaterials, materialIsSupported } from './lightScene';
 import {
   initializeWorkbench,
   traverseSceneItems,
@@ -177,9 +177,8 @@ async function runOffscreenWorkflow(
   const workbench = await initializeWorkbench(scene, settings, requestWork);
   // @todo this onWorkbenchDebug(workbench);
 
-  await withLightScene(workbench, async () => {
-    await runBakingPasses(workbench, requestWork);
-  });
+  await setLightSceneMaterials(workbench);
+  await runBakingPasses(workbench, requestWork);
 
   return workbench;
 }

--- a/src/core/Lightmap.tsx
+++ b/src/core/Lightmap.tsx
@@ -326,6 +326,8 @@ const Lightmap: React.FC<React.PropsWithChildren<LightmapProps>> = ({
     }
   }, [result]);
 
+  // show final scene only when baking is done because it may contain loaded GLTF mesh instances
+  // (which end up cached and reused, so only one scene can attach them at a time anyway)
   return (
     <DebugContext.Provider value={debugInfo}>
       {result ? (

--- a/src/core/Lightmap.tsx
+++ b/src/core/Lightmap.tsx
@@ -58,11 +58,13 @@ export const DebugContext = React.createContext<{
 } | null>(null);
 
 // set the computed irradiance texture on real scene materials
-export async function updateFinalSceneMaterials(workbench: Workbench) {
-  const { aoMode, lightScene, irradiance } = workbench;
-
+function updateFinalSceneMaterials(
+  scene: THREE.Scene,
+  irradiance: THREE.Texture,
+  aoMode: boolean
+) {
   // process relevant meshes
-  for (const object of traverseSceneItems(lightScene, false)) {
+  for (const object of traverseSceneItems(scene, false)) {
     // simple check for type (no need to check for uv2 presence)
     if (!(object instanceof THREE.Mesh)) {
       continue;
@@ -91,6 +93,7 @@ export async function updateFinalSceneMaterials(workbench: Workbench) {
     });
   }
 }
+
 // main asynchronous workflow sequence
 async function runWorkflow(
   scene: THREE.Scene,
@@ -105,7 +108,11 @@ async function runWorkflow(
     await runBakingPasses(workbench, requestWork);
   });
 
-  await updateFinalSceneMaterials(workbench);
+  updateFinalSceneMaterials(
+    workbench.lightScene,
+    workbench.irradiance,
+    workbench.aoMode
+  );
 
   return workbench.irradiance;
 }

--- a/src/core/Lightmap.tsx
+++ b/src/core/Lightmap.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT license
  */
 
-import React, { useState, useMemo, useLayoutEffect, useRef } from 'react';
+import React, { useState, useLayoutEffect, useRef } from 'react';
 import { useThree, createRoot } from '@react-three/fiber';
 import * as THREE from 'three';
 
@@ -249,7 +249,7 @@ const Lightmap: React.FC<React.PropsWithChildren<LightmapProps>> = ({
             );
 
             const outputTexture = new THREE.DataTexture(
-              new Float32Array(atlasMap.width * atlasMap.height),
+              new Float32Array(atlasMap.width * atlasMap.height * 4),
               atlasMap.width,
               atlasMap.height,
               THREE.RGBAFormat,

--- a/src/core/Lightmap.tsx
+++ b/src/core/Lightmap.tsx
@@ -7,7 +7,7 @@ import React, { useState, useLayoutEffect, useRef } from 'react';
 import { useThree, createRoot } from '@react-three/fiber';
 import * as THREE from 'three';
 
-import { setLightSceneMaterials, materialIsSupported } from './lightScene';
+import { withLightScene, materialIsSupported } from './lightScene';
 import {
   initializeWorkbench,
   traverseSceneItems,
@@ -187,11 +187,11 @@ async function runOffscreenWorkflow(
   const workbench = await initializeWorkbench(scene, settings, requestWork);
   debugListeners.onAtlasMap(workbench.atlasMap); // expose atlas map for debugging
 
-  await setLightSceneMaterials(workbench);
-
-  await runBakingPasses(workbench, requestWork, (data, width, height) => {
-    // expose current pass output for debugging
-    debugListeners.onPassComplete(data, width, height);
+  await withLightScene(workbench, async () => {
+    await runBakingPasses(workbench, requestWork, (data, width, height) => {
+      // expose current pass output for debugging
+      debugListeners.onPassComplete(data, width, height);
+    });
   });
 
   return workbench;

--- a/src/core/atlas.ts
+++ b/src/core/atlas.ts
@@ -17,7 +17,6 @@ export interface AtlasMap {
   height: number;
   items: AtlasMapItem[];
   data: Float32Array;
-  texture: THREE.Texture;
 }
 
 // must be black for full zeroing
@@ -306,13 +305,6 @@ export function renderAtlas(
   return {
     width: width,
     height: height,
-    texture: new THREE.DataTexture(
-      orthoData,
-      width,
-      height,
-      THREE.RGBAFormat,
-      THREE.FloatType
-    ),
     data: orthoData,
 
     // no need to expose references to atlas-specific geometry clones

--- a/src/core/bake.ts
+++ b/src/core/bake.ts
@@ -55,7 +55,8 @@ function storeLightMapValue(
 
 export async function runBakingPasses(
   workbench: Workbench,
-  requestWork: () => Promise<THREE.WebGLRenderer>
+  requestWork: () => Promise<THREE.WebGLRenderer>,
+  onDebugPassComplete?: (outputData: Float32Array) => void
 ) {
   await withLightProbe(
     workbench.aoMode,
@@ -100,9 +101,13 @@ export async function runBakingPasses(
         }
 
         // pass is complete, apply the computed texels into active lightmap
-        // (used in the next pass and final display)
+        // (used in the next pass)
         irradianceData.set(passOutputData);
         irradiance.needsUpdate = true;
+
+        if (onDebugPassComplete) {
+          onDebugPassComplete(passOutputData);
+        }
       }
     }
   );

--- a/src/core/bake.ts
+++ b/src/core/bake.ts
@@ -56,7 +56,11 @@ function storeLightMapValue(
 export async function runBakingPasses(
   workbench: Workbench,
   requestWork: () => Promise<THREE.WebGLRenderer>,
-  onDebugPassComplete?: (outputData: Float32Array) => void
+  onDebugPassComplete?: (
+    outputData: Float32Array,
+    width: number,
+    height: number
+  ) => void
 ) {
   await withLightProbe(
     workbench.aoMode,
@@ -106,7 +110,7 @@ export async function runBakingPasses(
         irradiance.needsUpdate = true;
 
         if (onDebugPassComplete) {
-          onDebugPassComplete(passOutputData);
+          onDebugPassComplete(passOutputData, atlasWidth, atlasHeight);
         }
       }
     }

--- a/src/core/lightScene.ts
+++ b/src/core/lightScene.ts
@@ -27,6 +27,9 @@ const ORIGINAL_MATERIAL_KEY = Symbol(
 );
 type UserDataStore<T extends symbol, V> = Record<T, V | undefined>;
 
+// set up baking-friendly materials and clean up when done
+// (the cleanup is done in case the scene contains loaded GLTF mesh instances,
+// they will be re-attached from baking scene to final scene as is)
 export async function withLightScene(
   workbench: Workbench,
   taskCallback: () => Promise<void>

--- a/src/core/lightScene.ts
+++ b/src/core/lightScene.ts
@@ -22,7 +22,15 @@ export function materialIsSupported(
   );
 }
 
-export async function setLightSceneMaterials(workbench: Workbench) {
+const ORIGINAL_MATERIAL_KEY = Symbol(
+  'lightmap baker: stashed original material'
+);
+type UserDataStore<T extends symbol, V> = Record<T, V | undefined>;
+
+export async function withLightScene(
+  workbench: Workbench,
+  taskCallback: () => Promise<void>
+) {
   // prepare the scene for baking
   const {
     aoMode,
@@ -33,17 +41,25 @@ export async function setLightSceneMaterials(workbench: Workbench) {
   } = workbench;
 
   // process relevant meshes
+  const meshCleanupList: THREE.Mesh[] = [];
+  const suppressedCleanupList: THREE.Object3D[] = [];
+
   for (const object of traverseSceneItems(
     lightScene,
     false,
     (ignoredObject) => {
       // also prevent ignored items from rendering
-      ignoredObject.visible = false;
+      // (do nothing if already invisible to avoid setting it back to visible on cleanup)
+      if (ignoredObject.visible) {
+        ignoredObject.visible = false;
+        suppressedCleanupList.push(ignoredObject);
+      }
     }
   )) {
     // hide any visible lights to prevent interfering with AO
     if (aoMode && object instanceof THREE.Light) {
       object.visible = false;
+      suppressedCleanupList.push(object);
       continue;
     }
 
@@ -156,10 +172,21 @@ export async function setLightSceneMaterials(workbench: Workbench) {
       return stagingMaterial;
     });
 
+    // stash original material list so that we can restore it later
+    (
+      mesh.userData as UserDataStore<
+        typeof ORIGINAL_MATERIAL_KEY,
+        THREE.Material[] | THREE.Material
+      >
+    )[ORIGINAL_MATERIAL_KEY] = mesh.material;
+
     // assign updated list or single material
     mesh.material = Array.isArray(mesh.material)
       ? stagingMaterialList
       : stagingMaterialList[0];
+
+    // keep a simple list for later cleanup
+    meshCleanupList.push(mesh);
   }
 
   let aoSceneLight: THREE.Light | null = null;
@@ -168,5 +195,39 @@ export async function setLightSceneMaterials(workbench: Workbench) {
     // (this lights the texels unmasked by previous AO passes for further propagation)
     aoSceneLight = new THREE.AmbientLight('#ffffff');
     lightScene.add(aoSceneLight);
+  }
+
+  // perform main task and then clean up regardless of error state
+  try {
+    await taskCallback();
+  } finally {
+    // remove the staging ambient light
+    if (aoSceneLight) {
+      lightScene.remove(aoSceneLight);
+    }
+
+    // re-enable suppressed items (and lights if AO)
+    suppressedCleanupList.forEach((object) => {
+      object.visible = true;
+    });
+
+    // replace staging material with original
+    meshCleanupList.forEach((mesh) => {
+      // get stashed material and clean up object key
+      const userData = mesh.userData as UserDataStore<
+        typeof ORIGINAL_MATERIAL_KEY,
+        THREE.Material[] | THREE.Material | null
+      >;
+      const origMaterialValue = userData[ORIGINAL_MATERIAL_KEY];
+      delete userData[ORIGINAL_MATERIAL_KEY];
+
+      if (!origMaterialValue) {
+        console.error('lightmap baker: missing original material', mesh);
+        return;
+      }
+
+      // restore original setting
+      mesh.material = origMaterialValue;
+    });
   }
 }

--- a/src/core/lightScene.ts
+++ b/src/core/lightScene.ts
@@ -5,13 +5,13 @@ import {
   traversalStateIsReadOnly
 } from './workbench';
 
-type SupportedMaterial =
+export type SupportedMaterial =
   | THREE.MeshLambertMaterial
   | THREE.MeshPhongMaterial
   | THREE.MeshStandardMaterial
   | THREE.MeshPhysicalMaterial;
 
-function materialIsSupported(
+export function materialIsSupported(
   material: THREE.Material
 ): material is SupportedMaterial {
   return (
@@ -198,10 +198,8 @@ export async function withLightScene(
   }
 
   // perform main task and then clean up regardless of error state
-  let finishedTask = false;
   try {
     await taskCallback();
-    finishedTask = true;
   } finally {
     // remove the staging ambient light
     if (aoSceneLight) {
@@ -230,30 +228,6 @@ export async function withLightScene(
 
       // restore original setting
       mesh.material = origMaterialValue;
-
-      // fill in the computed maps if task was successful
-      if (finishedTask) {
-        const materialList: (THREE.Material | null)[] = Array.isArray(
-          origMaterialValue
-        )
-          ? origMaterialValue
-          : [origMaterialValue];
-
-        materialList.forEach((material) => {
-          if (!material || !materialIsSupported(material)) {
-            return;
-          }
-
-          // set up our AO or lightmap as needed
-          if (aoMode) {
-            material.aoMap = irradiance;
-            material.needsUpdate = true;
-          } else {
-            material.lightMap = irradiance;
-            material.needsUpdate = true;
-          }
-        });
-      }
     });
   }
 }

--- a/src/core/workbench.ts
+++ b/src/core/workbench.ts
@@ -16,6 +16,8 @@ export interface Workbench {
   // lightmap output
   irradiance: THREE.Texture;
   irradianceData: Float32Array;
+  irradianceWidth: number;
+  irradianceHeight: number;
 
   // sampler settings
   settings: LightProbeSettings;
@@ -208,6 +210,8 @@ export async function initializeWorkbench(
 
     irradiance,
     irradianceData,
+    irradianceWidth: lightMapWidth,
+    irradianceHeight: lightMapHeight,
 
     settings: settings
   };

--- a/src/core/workbench.ts
+++ b/src/core/workbench.ts
@@ -9,6 +9,7 @@ export interface Workbench {
   aoDistance: number;
   emissiveMultiplier: number;
   bounceMultiplier: number;
+  texelsPerUnit: number;
 
   lightScene: THREE.Scene;
   atlasMap: AtlasMap;
@@ -150,25 +151,17 @@ export async function initializeWorkbench(
     ...samplerSettings
   };
 
-  // parse the convenience setting
-  const [initialWidth, initialHeight] = lightMapSize
-    ? [
-        typeof lightMapSize === 'number' ? lightMapSize : lightMapSize[0],
-        typeof lightMapSize === 'number' ? lightMapSize : lightMapSize[1]
-      ]
-    : [undefined, undefined];
-
   // wait a bit for responsiveness
   await requestNextTick();
 
   // perform UV auto-layout in next tick
+  const realTexelsPerUnit = texelsPerUnit || DEFAULT_TEXELS_PER_UNIT;
 
   const [computedWidth, computedHeight] = computeAutoUV2Layout(
-    initialWidth,
-    initialHeight,
+    lightMapSize,
     traverseSceneItems(scene, true),
     {
-      texelsPerUnit: texelsPerUnit || DEFAULT_TEXELS_PER_UNIT
+      texelsPerUnit: realTexelsPerUnit
     }
   );
 
@@ -204,6 +197,7 @@ export async function initializeWorkbench(
         ? DEFAULT_EMISSIVE_MULTIPLIER
         : emissiveMultiplier,
     bounceMultiplier: bounceMultiplier === undefined ? 1 : bounceMultiplier,
+    texelsPerUnit: realTexelsPerUnit,
 
     lightScene: scene,
     atlasMap,

--- a/src/core/workbench.ts
+++ b/src/core/workbench.ts
@@ -17,8 +17,8 @@ export interface Workbench {
   // lightmap output
   irradiance: THREE.Texture;
   irradianceData: Float32Array;
-  irradianceWidth: number;
-  irradianceHeight: number;
+
+  createOutputTexture: () => THREE.Texture;
 
   // sampler settings
   settings: LightProbeSettings;
@@ -204,8 +204,24 @@ export async function initializeWorkbench(
 
     irradiance,
     irradianceData,
-    irradianceWidth: lightMapWidth,
-    irradianceHeight: lightMapHeight,
+
+    // clone the lightmap/AO map to use in a different GL context
+    createOutputTexture(): THREE.Texture {
+      const texture = new THREE.DataTexture(
+        irradianceData,
+        lightMapWidth,
+        lightMapHeight,
+        THREE.RGBAFormat,
+        THREE.FloatType
+      );
+
+      // set same texture filter (no mipmaps supported due to the nature of lightmaps)
+      texture.magFilter = irradiance.magFilter;
+      texture.minFilter = irradiance.minFilter;
+      texture.generateMipmaps = false;
+
+      return texture;
+    },
 
     settings: settings
   };


### PR DESCRIPTION
Greatly improves separation of concerns, simplifies cleanup after baking, and could allow eventual web worker support. Prerequisite for re-enabling suspense while baking.